### PR TITLE
feat: allow direct access to caught error and `errorInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ Just trying things out or want to skip the build step? Use the unpkg URL:
 Whenever the component or a child component throws an error you can use this hook to catch the error and display an error UI to the user.
 
 ```jsx
-// error = `undefined`, or an object with the `error` and `errorInfo` keys.
+// error = `undefined`, or an Error object
 // resetError = Call this function to mark an error as resolved. It's
 //   up to your app to decide what that means and if it is possible
 //   to recover from errors.
-const [errorData, resetError] = useErrorBoundary();
+const [error, resetError] = useErrorBoundary();
 ```
 
 For application monitoring, it's often useful to notify a service of any errors. `useErrorBoundary` accepts an optional callback that will be invoked when an error is encountered.
 
 ```jsx
-const [errorData] = useErrorBoundary((error, errorInfo) =>
+const [error] = useErrorBoundary((error, errorInfo) =>
   logErrorToMyService(error, errorInfo)
 );
 ```
@@ -66,14 +66,12 @@ A full example may look like this:
 import { withErrorBoundary, useErrorBoundary } from "react-use-error-boundary";
 
 const App = withErrorBoundary(({ children }) => {
-  const [errorData, resetError] = useErrorBoundary(
+  const [error, resetError] = useErrorBoundary(
     // You can optionally log the error to an error reporting service
     (error, errorInfo) => logErrorToMyService(error, errorInfo)
   );
 
-  if (errorData) {
-    const { error } = errorData;
-
+  if (error) {
     return (
       <div>
         <p>{error.message}</p>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Just trying things out or want to skip the build step? Use the unpkg URL:
 Whenever the component or a child component throws an error you can use this hook to catch the error and display an error UI to the user.
 
 ```jsx
-// error = `undefined`, or an Error object
+// error = The error that was caught or `undefined` if nothing errored. If something other than an instance of `Error` was thrown, it will be wrapped in an `Error` object by calling `new Error()` on the thrown value.
 // resetError = Call this function to mark an error as resolved. It's
 //   up to your app to decide what that means and if it is possible
 //   to recover from errors.

--- a/README.md
+++ b/README.md
@@ -45,17 +45,19 @@ Just trying things out or want to skip the build step? Use the unpkg URL:
 Whenever the component or a child component throws an error you can use this hook to catch the error and display an error UI to the user.
 
 ```jsx
-// error = Whether an error was caught (true/false).
+// error = `undefined`, or an object with the `error` and `errorInfo` keys.
 // resetError = Call this function to mark an error as resolved. It's
 //   up to your app to decide what that means and if it is possible
 //   to recover from errors.
-const [error, resetError] = useErrorBoundary();
+const [errorData, resetError] = useErrorBoundary();
 ```
 
 For application monitoring, it's often useful to notify a service of any errors. `useErrorBoundary` accepts an optional callback that will be invoked when an error is encountered.
 
 ```jsx
-const [error] = useErrorBoundary((error) => callMyApi(error.message));
+const [errorData] = useErrorBoundary((error, errorInfo) =>
+  logErrorToMyService(error, errorInfo)
+);
 ```
 
 A full example may look like this:
@@ -63,22 +65,25 @@ A full example may look like this:
 ```jsx
 import { withErrorBoundary, useErrorBoundary } from "react-use-error-boundary";
 
-const App = withErrorBoundary({ children }) => {
-  const [error, resetError] = useErrorBoundary(
-    error => callMyApi(error.message)
+const App = withErrorBoundary(({ children }) => {
+  const [errorData, resetError] = useErrorBoundary(
+    // You can optionally log the error to an error reporting service
+    (error, errorInfo) => logErrorToMyService(error, errorInfo)
   );
 
-  if (error) {
+  if (errorData) {
+    const { error } = errorData;
+
     return (
       <div>
-        <p>An error occurred!</p>
+        <p>{error.message}</p>
         <button onClick={resetError}>Try again</button>
       </div>
     );
   }
 
-  return <div>{children}</div>
-};
+  return <div>{children}</div>;
+});
 ```
 
 Note that in addition to the hook, the component must be wrapped with `withErrorBoundary`. This function wraps the component with an Error Boundary and a context provider. Alternatively, the `<ErrorBoundaryContext>` component from this library may be placed in your component tree, above each component using `useErrorBoundary`.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ Whenever the component or a child component throws an error you can use this hoo
 const [error, resetError] = useErrorBoundary();
 ```
 
-For application monitoring, it's often useful to notify a service of any errors. `useErrorBoundary` accepts an optional callback that will be invoked when an error is encountered. The callback is invoked with `error` and `errorInfor` which are identical to [React's componentDidCatch arguments]( https://reactjs.org/docs/error-boundaries.html). Identical to React, `error` is the error that was thrown, and `errorInfo` is the component stack trace.
+For application monitoring, it's often useful to notify a service of any errors. `useErrorBoundary` accepts an optional callback that will be invoked when an error is encountered. The callback is invoked with `error` and `errorInfor` which are identical to [React's componentDidCatch arguments](https://reactjs.org/docs/error-boundaries.html). Identical to React, `error` is the error that was thrown, and `errorInfo` is the component stack trace.
 
 ```jsx
-const [error] = useErrorBoundary((error, errorInfo) => logErrorToMyService(error, errorInfo));
+const [error] = useErrorBoundary((error, errorInfo) =>
+  logErrorToMyService(error, errorInfo)
+);
 ```
 
 A full example may look like this:
@@ -89,7 +91,10 @@ This was done to avoid hooking into React internals, which would otherwise be re
 Alternatively, the `<ErrorBoundaryContext>` component from this library may be placed in your component tree, above each component using `useErrorBoundary`, instead of wrapping the component with `withErrorBoundary`:
 
 ```jsx
-import { ErrorBoundaryContext, useErrorBoundary } from "react-use-error-boundary";
+import {
+  ErrorBoundaryContext,
+  useErrorBoundary,
+} from "react-use-error-boundary";
 
 const App = ({ children }) => {
   // ... see function body in example above

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Just trying things out or want to skip the build step? Use the unpkg URL:
 Whenever the component or a child component throws an error you can use this hook to catch the error and display an error UI to the user.
 
 ```jsx
-// error = The error that was caught or `undefined` if nothing errored.
+// error = Whether an error was caught (true/false).
 // resetError = Call this function to mark an error as resolved. It's
 //   up to your app to decide what that means and if it is possible
 //   to recover from errors.
@@ -71,7 +71,7 @@ const App = withErrorBoundary({ children }) => {
   if (error) {
     return (
       <div>
-        <p>{error.message}</p>
+        <p>An error occurred!</p>
         <button onClick={resetError}>Try again</button>
       </div>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,9 +23,8 @@ interface ErrorBoundaryProps {
 }
 
 /**
- * Wrapper around the `Error` class to allow us to create an error
- * message while retaining the originally thrown data as an attribute
- * on the class.
+ * Wrapper that is instantiated for thrown primitives so that consumers always work with the `Error` interface.
+ * The thrown primitive can be accessed via the `originalData` property.
  */
 export class WrappedError extends Error {
   /**
@@ -34,10 +33,9 @@ export class WrappedError extends Error {
    */
   originalData: unknown;
 
-  constructor(data?: unknown) {
-    let stringifiedData =
-      "It was not possible to parse the data thrown as a string.";
+  constructor(error: unknown) {
 
+  console.warn("react-use-error-boundary: A value was thrown that is not an instance of Error. Thrown values should be instantiated with JavaScript's Error constructor.");
     /*
       Some values cannot be converted into a string, such as Symbols
       or certain Object instances (e.g., `Object.create(null)`).
@@ -47,18 +45,17 @@ export class WrappedError extends Error {
       when we're meant to be preventing errors doing so.
     */
     try {
-      stringifiedData = String(data);
+      super(error);
     } catch {
-      // Ignore errors
+      super("react-use-error-boundary: Could not instantiate an Error with the thrown value. The thrown value may can be accessed via the originalError property");
     }
-
-    super(stringifiedData);
+    this.name = "WrappedError";
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, WrappedError)
     }
     // Save a copy of the original non-stringified data
-    this.originalData = data;
+    this.originalError = error;
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,10 @@ export class WrappedError extends Error {
     }
 
     super(stringifiedData);
-
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, WrappedError)
+    }
     // Save a copy of the original non-stringified data
     this.originalData = data;
   }


### PR DESCRIPTION
The `error` value returned by the hook call is a boolean, not the actual caught error.

The TS typings reflect this, but the readme documentation does not.