### PR TITLE
remove error wrapping for thrown primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.0.0
+
+```js
+const [error] = useErrorBoundary();
+```
+
+- The `error` wrapping that was introduced in v2 has been removed. `error` will now be the error that was caught without any wrapping for thrown primitives. The types have been updated to `unknown` to reflect that thrown JavaScript errors may be any type not just instances of `Error`.
+
+- `withErrorBoundary` now propagates the wrapped component display name for improved debugging with React dev tools. It will display as `WithErrorBoundary(${Component.displayName})`.
+
 ## v2.0.1
 
 Publish CommonJS and ESM.

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -15,9 +15,10 @@ const App: FC = withErrorBoundary(() => {
   });
 
   if (error) {
+    const message = error instanceof Error ? error.message : (error as string);
     return (
       <>
-        <div>Error: {error.message}</div>
+        <div>Error: {message}</div>
         <button
           onClick={() => {
             setShouldThrow(false);

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -31,60 +31,30 @@ describe(useErrorBoundary, () => {
     expect(componentDidCatch).toHaveBeenCalledTimes(1);
   });
 
-  describe("ReactUseErrorBoundaryWrappedError", () => {
-    it("wraps thrown values that are not Error instances with ReactUseErrorBoundaryWrappedError", () => {
-      let error;
+  it("thrown primitives", () => {
+    let error;
 
-      const ThrowNonError: FC = () => {
-        throw "Bombs away 💣";
-      };
+    const ThrowNonError: FC = () => {
+      throw "Bombs away 💣";
+    };
 
-      const Example: FC = withErrorBoundary(() => {
-        [error] = useErrorBoundary();
-        if (error) {
-          return <p>Error: {error.message}</p>;
-        }
+    const Example: FC = withErrorBoundary(() => {
+      [error] = useErrorBoundary();
+      if (error) {
+        return <p>Error: {error as string}</p>;
+      }
 
-        return <ThrowNonError />;
-      });
+      return <ThrowNonError />;
+    });
 
-      render(<Example />);
+    render(<Example />);
 
-      expect(screen.queryByText(/Error:/)).toMatchInlineSnapshot(`
+    expect(screen.queryByText(/Error:/)).toMatchInlineSnapshot(`
         <p>
           Error: 
           Bombs away 💣
         </p>
       `);
-    });
-
-    it("handles thrown values that can not be passed to Error's constructor", () => {
-      let error: Error | undefined;
-
-      const thrownError = Symbol("Foo");
-
-      const ThrowNonError: FC = () => {
-        throw thrownError;
-      };
-
-      const Example: FC = withErrorBoundary(() => {
-        [error] = useErrorBoundary();
-        if (error) {
-          return null;
-        }
-
-        return <ThrowNonError />;
-      });
-
-      render(<Example />);
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unsafe-member-access
-      expect(error!.message).toMatchInlineSnapshot(
-        `"react-use-error-boundary: Could not instantiate an Error with the thrown value. The thrown value can be accessed via the 'originalError' property"`
-      );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-      expect((error as any).originalError).toEqual(thrownError);
-    });
   });
 
   it("does not invoke the componentDidCatch handler when there is not an error", () => {


### PR DESCRIPTION
fixes #13 (indirectly, through the removal of class shorthands).